### PR TITLE
add properties files to xpi files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,13 @@ endif
 endif
 endif
 
+XPI_CONTENTS:=$(shell find chrome -name "*.html" -o -name "*.xhtml" -o -name "*.css" -o -name "*.png" -o -name "*.gif" -o -name "*.js" -o -name "*.jsm" -o -name "*.dtd" -o -name "*.xul" -o -name "messages" -o -name "*.properties") chrome.manifest install.rdf COPYING
+
+bitmask.xpi: $(XPI_CONTENTS)
+	zip $@ $(XPI_CONTENTS)
+
+xpi_release:
+	ln -s $(XPINAME) $(PKGNAME) 
 
 # main rule
 all: clean $(TARGET)


### PR DESCRIPTION
This is a merge from the Makefile in the debian branch.
bitmask.xpi rule is the one expected/used by the debhelper.

I think it was not correctly included or merged in a past pullreq.
